### PR TITLE
Make variables needed for nfsv3 configurable

### DIFF
--- a/modules/storage_account_private/main.tf
+++ b/modules/storage_account_private/main.tf
@@ -19,10 +19,11 @@ resource "azurerm_storage_account" "storage_account" {
   account_kind              = var.kind
   account_tier              = var.tier
   account_replication_type  = var.replication_type
-  enable_https_traffic_only = true
+  enable_https_traffic_only = var.enable_https_traffic_only
   allow_blob_public_access  = false
   min_tls_version           = var.min_tls_version
   nfsv3_enabled             = var.nfsv3_enabled
+  is_hns_enabled            = var.is_hns_enabled
 
   network_rules {
     default_action = "Deny"

--- a/modules/storage_account_private/variables.tf
+++ b/modules/storage_account_private/variables.tf
@@ -47,3 +47,15 @@ variable "nfsv3_enabled" {
   description = "Is NFSv3 protocol enabled?"
   default     = false
 }
+
+variable "is_hns_enabled" {
+  type        = bool
+  description = "Is Hierarchical Namespace enabled?"
+  default     = false
+}
+
+variable "enable_https_traffic_only" {
+  type        = bool
+  description = "Forces HTTPS when true"
+  default     = true
+}

--- a/modules/storage_account_public/main.tf
+++ b/modules/storage_account_public/main.tf
@@ -19,8 +19,9 @@ resource "azurerm_storage_account" "storage_account" {
   account_kind              = var.kind
   account_tier              = var.tier
   account_replication_type  = var.replication_type
-  enable_https_traffic_only = true
+  enable_https_traffic_only = var.enable_https_traffic_only
   allow_blob_public_access  = var.allow_public_access
   min_tls_version           = var.min_tls_version
   nfsv3_enabled             = var.nfsv3_enabled
+  is_hns_enabled            = var.is_hns_enabled
 }

--- a/modules/storage_account_public/variables.tf
+++ b/modules/storage_account_public/variables.tf
@@ -48,3 +48,15 @@ variable "nfsv3_enabled" {
   description = "Is NFSv3 protocol enabled?"
   default     = false
 }
+
+variable "is_hns_enabled" {
+  type        = bool
+  description = "Is Hierarchical Namespace enabled?"
+  default     = false
+}
+
+variable "enable_https_traffic_only" {
+  type        = bool
+  description = "Forces HTTPS when true"
+  default     = true
+}


### PR DESCRIPTION
Missed the part of the [Terraform documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) which state that some variables had to be set correctly in order to use NFS