### PR TITLE
Module storage queue

### DIFF
--- a/modules/storage_queue/main.tf
+++ b/modules/storage_queue/main.tf
@@ -1,8 +1,8 @@
 terraform {
-  required_version = ">=0.14.9"
+  required_version = ">=1.1.7"
 
   required_providers {
-    azurerm = "=2.70.0"
+    azurerm = "=2.98.0"
   }
 
   backend "azurerm" {}

--- a/modules/storage_queue/main.tf
+++ b/modules/storage_queue/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">=0.14.9"
+
+  required_providers {
+    azurerm = "=2.70.0"
+  }
+
+  backend "azurerm" {}
+}
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_storage_queue" "storage_queue" {
+  for_each             = var.queue_names
+  name                 = each.value
+  storage_account_name = var.storage_account_name
+}

--- a/modules/storage_queue/outputs.tf
+++ b/modules/storage_queue/outputs.tf
@@ -1,5 +1,3 @@
-variable "queue_names" {
-  type        = set(string)
-  description = "Add predefined queue names in this storage."
-  default     = []
+output "storage_queues" {
+  value = azurerm_storage_queue.storage_queue
 }

--- a/modules/storage_queue/outputs.tf
+++ b/modules/storage_queue/outputs.tf
@@ -1,0 +1,5 @@
+variable "queue_names" {
+  type        = set(string)
+  description = "Add predefined queue names in this storage."
+  default     = []
+}

--- a/modules/storage_queue/variables.tf
+++ b/modules/storage_queue/variables.tf
@@ -2,3 +2,9 @@ variable "storage_account_name" {
   type        = string
   description = "Name of the storage account"
 }
+
+variable "queue_names" {
+  type        = set(string)
+  description = "Add predefined queue names in this storage."
+  default     = []
+}

--- a/modules/storage_queue/variables.tf
+++ b/modules/storage_queue/variables.tf
@@ -1,0 +1,4 @@
+variable "storage_account_name" {
+  type        = string
+  description = "Name of the storage account"
+}


### PR DESCRIPTION
Possibility to add storage queues to a storage account

terragrunt.hcl

dependency "storage_account" {
  config_path = "../storage_account"
}

inputs = {
  queue_names               = ["sync-create","sync-create-poison","sync-update","sync-update-poison","sync-delete","sync-delete-poison"]
  storage_account_name      = dependency.storage_account.outputs.storage_account_name
}