### PR TITLE
PM-23 - Allow for multiple in-/outputs

### DIFF
--- a/modules/stream_analytics/main.tf
+++ b/modules/stream_analytics/main.tf
@@ -13,20 +13,18 @@ provider "azurerm" {
 }
 
 locals {
-  stream_output_name = "${var.name}-output"
-  stream_input_name  = "${var.name}-input"
-  stream_job_name    = "${var.name}-job"
-
-  select_all_query = "SELECT * INTO \"${local.stream_output_name}\" FROM \"${local.stream_input_name}\""
+  eventhub_inputs = { for eventhub_input in var.eventhub_inputs : eventhub_input.name => eventhub_input }
+  blob_outputs    = { for blob_output in var.blob_outputs : blob_output.name => blob_output }
 }
 
-data "azurerm_eventhub_namespace" "namespace" {
-  name                = var.eventhub_namespace_name
+data "azurerm_eventhub_namespace" "namespaces" {
+  for_each            = local.eventhub_inputs
+  name                = each.value.eventhub_namespace_name
   resource_group_name = var.resource_group_name
 }
 
 resource "azurerm_stream_analytics_job" "job" {
-  name                                     = local.stream_job_name
+  name                                     = var.name
   resource_group_name                      = var.resource_group_name
   location                                 = var.location
   compatibility_level                      = var.stream_compatibility_level
@@ -36,39 +34,41 @@ resource "azurerm_stream_analytics_job" "job" {
   events_out_of_order_policy               = var.stream_out_of_order_policy
   output_error_policy                      = var.stream_error_policy
   streaming_units                          = var.stream_streaming_units
-  transformation_query                     = var.stream_query == null ? local.select_all_query : var.stream_query
+  transformation_query                     = var.stream_query
 }
 
 resource "azurerm_stream_analytics_stream_input_eventhub" "stream_input" {
-  name                         = local.stream_input_name
+  for_each                     = local.eventhub_inputs
+  name                         = each.value.name
   stream_analytics_job_name    = azurerm_stream_analytics_job.job.name
   resource_group_name          = var.resource_group_name
-  eventhub_consumer_group_name = var.eventhub_consumer_group_name
-  eventhub_name                = var.eventhub_name
-  servicebus_namespace         = var.eventhub_namespace_name
-  shared_access_policy_key     = data.azurerm_eventhub_namespace.namespace.default_primary_key
-  shared_access_policy_name    = var.eventhub_access_policy_name
+  eventhub_consumer_group_name = each.value.eventhub_consumer_group_name
+  eventhub_name                = each.value.eventhub_name
+  servicebus_namespace         = each.value.eventhub_namespace_name
+  shared_access_policy_key     = data.azurerm_eventhub_namespace.namespaces[each.key].default_primary_key // TODO
+  shared_access_policy_name    = each.value.eventhub_access_policy_name
 
   serialization {
-    type     = var.serialization_type
-    encoding = var.serialization_name
+    type     = each.value.serialization.type
+    encoding = each.value.serialization.encoding
   }
 }
 
 resource "azurerm_stream_analytics_output_blob" "stream_output" {
-  name                      = local.stream_output_name
+  for_each                  = local.blob_outputs
+  name                      = each.value.name
   stream_analytics_job_name = azurerm_stream_analytics_job.job.name
   resource_group_name       = var.resource_group_name
-  storage_account_name      = var.storage_account_name
-  storage_account_key       = var.storage_connection_string
-  storage_container_name    = var.storage_container_name
-  path_pattern              = var.stream_output_path_pattern
-  date_format               = var.stream_output_date_format
-  time_format               = var.stream_output_time_format
+  storage_account_name      = each.value.storage_account_name
+  storage_account_key       = each.value.storage_account_connection_string
+  storage_container_name    = each.value.storage_container_name
+  path_pattern              = each.value.path_pattern
+  date_format               = each.value.date_format
+  time_format               = each.value.time_format
 
   serialization {
-    type     = var.serialization_type
-    encoding = var.serialization_name
-    format   = var.serialization_format
+    type     = each.value.serialization.type
+    encoding = each.value.serialization.encoding
+    format   = each.value.serialization.format
   }
 }

--- a/modules/stream_analytics/main.tf
+++ b/modules/stream_analytics/main.tf
@@ -45,7 +45,7 @@ resource "azurerm_stream_analytics_stream_input_eventhub" "stream_input" {
   eventhub_consumer_group_name = each.value.eventhub_consumer_group_name
   eventhub_name                = each.value.eventhub_name
   servicebus_namespace         = each.value.eventhub_namespace_name
-  shared_access_policy_key     = data.azurerm_eventhub_namespace.namespaces[each.key].default_primary_key // TODO
+  shared_access_policy_key     = data.azurerm_eventhub_namespace.namespaces[each.key].default_primary_key
   shared_access_policy_name    = each.value.eventhub_access_policy_name
 
   serialization {

--- a/modules/stream_analytics/main.tf
+++ b/modules/stream_analytics/main.tf
@@ -34,7 +34,7 @@ resource "azurerm_stream_analytics_job" "job" {
   events_out_of_order_policy               = var.stream_out_of_order_policy
   output_error_policy                      = var.stream_error_policy
   streaming_units                          = var.stream_streaming_units
-  transformation_query                     = var.stream_query
+  transformation_query                     = var.stream_query == null ? "SELECT * INTO [${local.blob_outputs[0].name}] FROM [${local.eventhub_inputs[0].name}]" : var.stream_query
 }
 
 resource "azurerm_stream_analytics_stream_input_eventhub" "stream_input" {

--- a/modules/stream_analytics/main.tf
+++ b/modules/stream_analytics/main.tf
@@ -52,6 +52,13 @@ resource "azurerm_stream_analytics_stream_input_eventhub" "stream_input" {
     type     = each.value.serialization.type
     encoding = each.value.serialization.encoding
   }
+
+  provisioner "local-exec" {
+    // Strange, no?
+    // Terraform does not support setting/updating the compression type.
+    // Azure barely does... We also update the "partitionKey" so that Azure will Recognize it as an actual update.
+    command = "az stream-analytics input update --properties '{\"type\":\"Stream\",\"compression\":{\"type\":\"${each.value.compression_type}\"},\"partitionKey\":\"\"}' -g ${var.resource_group_name} --job-name ${azurerm_stream_analytics_job.job.name} -n ${each.value.name}"
+  }
 }
 
 resource "azurerm_stream_analytics_output_blob" "stream_output" {

--- a/modules/stream_analytics/outputs.tf
+++ b/modules/stream_analytics/outputs.tf
@@ -2,14 +2,6 @@ output "stream_analytics_job_name" {
   value = azurerm_stream_analytics_job.job.name
 }
 
-output "stream_input_name" {
-  value = azurerm_stream_analytics_stream_input_eventhub.stream_input.name
-}
-
-output "stream_output_name" {
-  value = azurerm_stream_analytics_output_blob.stream_output.name
-}
-
 output "stream_job_id" {
   value = azurerm_stream_analytics_job.job.id
 }

--- a/modules/stream_analytics/set_compression_type.sh
+++ b/modules/stream_analytics/set_compression_type.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Azure does not see changing 'compression.type' as a change. Therefor we statically
+# update 'partitionKey' as well.
+
+while getopts :g:j:i:c: flag
+do
+    case "${flag}" in
+        g) resource_group=${OPTARG};;
+        j) job_name=${OPTARG};;
+        i) input_name=${OPTARG};;
+        c) compression_type=${OPTARG};;
+    esac
+done
+
+az stream-analytics input update \
+--properties "{\"type\":\"Stream\",\"compression\":{\"type\":\"$compression_type\"},\"partitionKey\":\"\"}" \
+-g $resource_group \
+--job-name $job_name \
+-n $input_name

--- a/modules/stream_analytics/variables.tf
+++ b/modules/stream_analytics/variables.tf
@@ -20,6 +20,7 @@ variable "eventhub_inputs" {
     eventhub_namespace_name      = string,
     eventhub_consumer_group_name = string,
     eventhub_access_policy_name  = string, // Default: "RootManageSharedAccessKey"
+    compression_type             = string, // Default: "None"
 
     serialization = object({
       type     = string, // Default: "Json"

--- a/modules/stream_analytics/variables.tf
+++ b/modules/stream_analytics/variables.tf
@@ -5,7 +5,7 @@ variable "location" {
 
 variable "name" {
   type        = string
-  description = "Name of resource."
+  description = "Name of the Azure Stream Analytics job."
 }
 
 variable "resource_group_name" {
@@ -13,35 +13,37 @@ variable "resource_group_name" {
   description = "Name of the resource group."
 }
 
-variable "storage_connection_string" {
-  type        = string
-  description = "Connection string of the storage account."
-  sensitive   = true
+variable "eventhub_inputs" {
+  type = list(object({
+    name                         = string,
+    eventhub_name                = string,
+    eventhub_namespace_name      = string,
+    eventhub_consumer_group_name = string,
+    eventhub_access_policy_name  = string, // Default: "RootManageSharedAccessKey"
+
+    serialization = object({
+      type     = string, // Default: "Json"
+      encoding = string  // Default: "UTF8"
+    })
+  }))
 }
 
-variable "storage_account_name" {
-  type        = string
-  description = "Name of the storage account."
-}
+variable "blob_outputs" {
+  type = list(object({
+    name                              = string,
+    storage_account_name              = string,
+    storage_account_connection_string = string,
+    storage_container_name            = string,
+    path_pattern                      = string,
+    date_format                       = string, // Default: "yyyy/MM/dd"
+    time_format                       = string, // Default: "HH"
 
-variable "storage_container_name" {
-  type        = string
-  description = "Name of the storage container."
-}
-
-variable "eventhub_name" {
-  type        = string
-  description = "Name of the event hub."
-}
-
-variable "eventhub_namespace_name" {
-  type        = string
-  description = "Name of the event hub namespace."
-}
-
-variable "eventhub_consumer_group_name" {
-  type        = string
-  description = "Name of the eventhub consumer group."
+    serialization = object({
+      type     = string, // Default: "Json"
+      encoding = string, // Default: "UTF8"
+      format   = string  // Default: "Array"
+    })
+  }))
 }
 
 variable "stream_compatibility_level" {
@@ -86,49 +88,7 @@ variable "stream_streaming_units" {
   default     = 1
 }
 
-variable "serialization_type" {
-  type        = string
-  description = "The serialization type used."
-  default     = "Json"
-}
-
-variable "serialization_name" {
-  type        = string
-  description = "The encoding of the data."
-  default     = "UTF8"
-}
-
-variable "serialization_format" {
-  type        = string
-  description = "The output format of the data."
-  default     = "Array"
-}
-
-variable "stream_output_path_pattern" {
-  type        = string
-  description = "The blob path pattern. "
-}
-
-variable "stream_output_date_format" {
-  type        = string
-  description = "The date output format."
-  default     = "yyyy/MM/dd"
-}
-
-variable "stream_output_time_format" {
-  type        = string
-  description = "The time output format."
-  default     = "HH"
-}
-
 variable "stream_query" {
   type        = string
   description = "SAQL query that will be run in the streaming job."
-  default     = null # Null values will be set to select all in main.tf
-}
-
-variable "eventhub_access_policy_name" {
-  type        = string
-  description = "The shared access policy name for the event hub."
-  default     = "RootManageSharedAccessKey"
 }

--- a/modules/stream_analytics/variables.tf
+++ b/modules/stream_analytics/variables.tf
@@ -91,4 +91,5 @@ variable "stream_streaming_units" {
 variable "stream_query" {
   type        = string
   description = "SAQL query that will be run in the streaming job."
+  default     = null
 }


### PR DESCRIPTION
Stream Analytics is very powerful when having multiple in-/outputs. The variable naming also makes it easier to add other types of inputs and outputs later on.

This is also needed for PM-23.

Unfortunately we lose some default variables due to nesting, I commented the default values after the variable declaration. It will be possible to add default values for nested variables once the, currently experimental, feature is released.