### PR TITLE
added default vars according to story

### DIFF
--- a/modules/service_bus_topic/main.tf
+++ b/modules/service_bus_topic/main.tf
@@ -13,10 +13,16 @@ provider "azurerm" {
 }
 
 resource "azurerm_servicebus_topic" "service_bus_topic" {
-  name                          = var.name
-  namespace_id                  = var.namespace_id
-  default_message_ttl           = var.default_message_ttl
-  max_size_in_megabytes         = var.max_size_in_megabytes
-  enable_partitioning           = var.enable_partitioning
-  requires_duplicate_detection  = var.requires_duplicate_detection
+  name                                    = var.name
+  namespace_id                            = var.namespace_id
+  default_message_ttl                     = var.default_message_ttl
+  max_size_in_megabytes                   = var.max_size_in_megabytes
+  enable_partitioning                     = var.enable_partitioning
+  requires_duplicate_detection            = var.requires_duplicate_detection
+  duplicate_detection_history_time_window = var.duplicate_detection_history_time_window
+  enable_batched_operations               = var.enable_batched_operations
+  status                                  = var.status
+  support_ordering                        = var.support_ordering
+  auto_delete_on_idle                     = var.auto_delete_on_idle
+  enable_express                          = var.enable_express
 }

--- a/modules/service_bus_topic/variables.tf
+++ b/modules/service_bus_topic/variables.tf
@@ -11,7 +11,7 @@ variable "namespace_id" {
 variable "default_message_ttl" {
   type        = string
   description = "Default TTL (time to live) of messages with unspecified TTL."
-  default     = "P30D" # (Arbitrary) 30 day TTL (in ISO 8601 format).
+  default     = "P14D" # 14 day TTL (in ISO 8601 format).
 }
 
 variable "max_size_in_megabytes" {
@@ -29,5 +29,41 @@ variable "enable_partitioning" {
 variable "requires_duplicate_detection" {
   type        = bool
   description = "Enable duplication detection."
+  default     = false
+}
+
+variable "duplicate_detection_history_time_window" {
+  type        = string
+  description = "ISO 8601 timespan duration during which duplicates can be detected."
+  default     = "PT10M" # 10 minutes in ISO 8601 (portal default)
+}
+
+variable "enable_batched_operations" {
+  type        = bool
+  description = "Enables Server-Side batched operations."
+  default     = true
+}
+
+variable "status" {
+  type        = string
+  description = "The Status of the Service Bus Topic."
+  default     = "Active"
+}
+
+variable "support_ordering" {
+  type        = bool
+  description = "Whether or not the topic supports ordering"
+  deault      = true
+}
+
+variable "auto_delete_on_idle" {
+  type        = string
+  description = "timespan duration of the idle interval after which the Topic is automatically deleted."
+  default     = "P10675199DT2H48M5.4775807S" # Maximum allowed time (ISO 8601 format)
+}
+
+variable "enable_express" {
+  type        = bool
+  description = "Whether Express Entities are enabled."
   default     = false
 }


### PR DESCRIPTION
Defaults set/added according to story AB#7982:
default_message_ttl: "P14D",
max_size_in_megabytes: 1024,
requires_duplicate_detection: false,
duplicate_detection_history_time_window: "PT10M",
enable_batched_operations: true,
status: "Active",
support_ordering: true,
auto_delete_on_idle: "P10675199DT2H48M5.4775807S"
enable_partitioning: false,
enable_express: false