### PR TITLE
TD-234. Extend public app service with logging configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ az account set --subscription $SUBSCRIPTION_ID
 
 # Create resource group
 az group create \
-  --subscription $env:SUBSCRIPTION_ID \
+  --subscription $SUBSCRIPTION_ID \
   --name $RESOURCE_GROUP_NAME \
   --location $LOCATION
 
 # Create storage account
 az storage account create \
-  --subscription $env:SUBSCRIPTION_ID \
+  --subscription $SUBSCRIPTION_ID \
   --name $STORAGE_ACCOUNT_NAME \
   --resource-group $RESOURCE_GROUP_NAME \
   --location $LOCATION \
@@ -94,17 +94,25 @@ az storage account create \
 
 # Get storage account key
 ACCOUNT_KEY=$(az storage account keys list \
-  --subscription $env:SUBSCRIPTION_ID \
+  --subscription $SUBSCRIPTION_ID \
   --resource-group $RESOURCE_GROUP_NAME \
   --account-name $STORAGE_ACCOUNT_NAME \
   --query '[0].value' -o tsv)
 
 # Create blob container
 az storage container create \
-  --subscription $env:SUBSCRIPTION_ID \
+  --subscription $SUBSCRIPTION_ID \
   --name $CONTAINER_NAME \
   --account-name $STORAGE_ACCOUNT_NAME \
   --account-key $ACCOUNT_KEY
+
+# Lock storage account
+az lock create \
+  --name CanNotDelete \
+  --lock-type CanNotDelete \
+  --resource-group $RESOURCE_GROUP_NAME \
+  --resource-name $STORAGE_ACCOUNT_NAME \
+  --resource-type Microsoft.Storage/storageAccounts
 ```
 
 #### Windows Powershell
@@ -115,31 +123,39 @@ $env:RESOURCE_GROUP_NAME="xxxxx"
 $env:STORAGE_ACCOUNT_NAME="xxxxx"
 $env:CONTAINER_NAME="tfstate"
 $env:LOCATION="westeurope"
- az group create  `
+
+az group create `
   --subscription $env:SUBSCRIPTION_ID `
-  --name $env:RESOURCE_GROUP_NAME  `
+  --name $env:RESOURCE_GROUP_NAME `
   --location $env:LOCATION
 
- az storage account create  `
+az storage account create `
   --subscription $env:SUBSCRIPTION_ID `
-  --name $env:STORAGE_ACCOUNT_NAME  `
-  --resource-group $env:RESOURCE_GROUP_NAME  `
-  --location $env:LOCATION  `
-  --sku Standard_LRS  `
-  --encryption-services blob  `
-  --https-only true  `
+  --name $env:STORAGE_ACCOUNT_NAME `
+  --resource-group $env:RESOURCE_GROUP_NAME `
+  --location $env:LOCATION `
+  --sku Standard_LRS`
+  --encryption-services blob `
+  --https-only true `
   --allow-blob-public-access false
 
- $output = az storage account keys list  `
+$output = az storage account keys list `
   --subscription $env:SUBSCRIPTION_ID `
-  --resource-group $env:RESOURCE_GROUP_NAME  `
-  --account-name $env:STORAGE_ACCOUNT_NAME  `
-  --query '[0].value'  `
+  --resource-group $env:RESOURCE_GROUP_NAME `
+  --account-name $env:STORAGE_ACCOUNT_NAME `
+  --query '[0].value' `
   -o tsv
 
- az storage container create  `
+az storage container create `
   --subscription $env:SUBSCRIPTION_ID `
-  --name $env:CONTAINER_NAME  `
-  --account-name $env:STORAGE_ACCOUNT_NAME  `
-  --account-key $ACCOUNT_KEY $output
+  --name $env:CONTAINER_NAME `
+  --account-name $env:STORAGE_ACCOUNT_NAME `
+  --account-key $output
+
+az lock create `
+  --name CanNotDelete `
+  --lock-type CanNotDelete `
+  --resource-group $env:RESOURCE_GROUP_NAME `
+  --resource-name $env:STORAGE_ACCOUNT_NAME `
+  --resource-type Microsoft.Storage/storageAccounts
 ```

--- a/examples/.github/workflows/ci.yaml
+++ b/examples/.github/workflows/ci.yaml
@@ -28,9 +28,9 @@ jobs:
     concurrency: $${{ needs.determine-environment.outputs.environment }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v1
+      uses: hashicorp/setup-terraform@v2
       with:
         terraform_wrapper: false
     - name: Setup Terragrunt

--- a/examples/README.md
+++ b/examples/README.md
@@ -155,7 +155,7 @@ jobs:
       TF_WORKING_DIR: terraform
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup
         run: brew install terragrunt
       - name: Apply

--- a/modules/app_service_public/main.tf
+++ b/modules/app_service_public/main.tf
@@ -74,3 +74,44 @@ resource "azurerm_app_service_custom_hostname_binding" "custom_domain" {
   app_service_name    = azurerm_app_service.app_service.name
   resource_group_name = var.resource_group_name
 }
+
+data "azurerm_monitor_diagnostic_categories" "diagnostic_categories" {
+  count       = var.log_analytics_workspace_id == null ? 0 : 1
+  resource_id = azurerm_app_service.app_service.id
+}
+
+resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
+  count                      = var.log_analytics_workspace_id == null ? 0 : 1
+  name                       = "diag-${var.name}"
+  target_resource_id         = azurerm_app_service.app_service.id
+  log_analytics_workspace_id = var.log_analytics_workspace_id
+
+  // TODO: not yet implemented by Azure
+  // log_analytics_destination_type = "Dedicated"
+
+  dynamic "log" {
+    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].logs
+
+    content {
+      category = log.value
+      enabled  = true
+
+      retention_policy {
+        enabled = false
+      }
+    }
+  }
+
+  dynamic "metric" {
+    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].metrics
+
+    content {
+      category = metric.value
+      enabled  = true
+
+      retention_policy {
+        enabled = false
+      }
+    }
+  }
+}

--- a/modules/app_service_public/variables.tf
+++ b/modules/app_service_public/variables.tf
@@ -135,3 +135,9 @@ variable "allowed_audiences" {
   description = "Allowed audience values to consider when validating JWTs issued by Azure Active Directory."
   default     = []
 }
+
+variable "log_analytics_workspace_id" {
+  type        = string
+  description = "ID of a log analytics workspace (optional)."
+  default     = null
+}


### PR DESCRIPTION
* Extend public app service with logging configuration.

Note: maybe in the future we should remove public/private distinction of all modules. It sounded like a good idea but gives overhead in terms of maintenance. The only difference is a private endpoint which is based on an input subnet_id.