### PR TITLE
8976. Hotfix for APIM custom domains

### DIFF
--- a/modules/api_management_custom_domains/variables.tf
+++ b/modules/api_management_custom_domains/variables.tf
@@ -10,6 +10,6 @@ variable "custom_domains" {
     certificate_name = string,
     key_vault_id     = string,
   }))
-  description = "List of custom domains and certificate references for API Management. Type must be one of gateway, management and developer_portal."
-  default     = []
+  description = "List of custom domains and certificate references for API Management. Type must be one of gateway, management or developer_portal."
+  default     = null
 }


### PR DESCRIPTION
* Only one custom domain resource allowed for api_management_custom_domain, using dynamic blocks for list items