### PR TITLE
Added default ConsumeAll filter when no filter specified for SBS

### DIFF
--- a/modules/azure/service_bus_subscription/main.tf
+++ b/modules/azure/service_bus_subscription/main.tf
@@ -55,3 +55,13 @@ resource "azurerm_servicebus_subscription_rule" "correlation_filter" {
     properties          = var.correlation_filter.properties
   }
 }
+
+# When no filter is specified, we create a default to capture all (otherwise, the subs is unreachable)
+# This filter is automatically create by Azure during initial create, but is not created during update (if someone deletes a filter)
+resource "azurerm_servicebus_subscription_rule" "default_route_all_sql_filter" {
+  count           = var.sql_filter_query == null && var.correlation_filter == null ? 1 : 0
+  name            = "Default-ConsumeAll"
+  subscription_id = azurerm_servicebus_subscription.service_bus_subscription.id
+  filter_type     = "SqlFilter"
+  sql_filter      = "1=1"
+}


### PR DESCRIPTION
When creating a new subscription without any filter specified, Azure automatically creates a default filter which captures all messages
![image](https://github.com/recognizegroup/terraform/assets/73311540/4fa23bca-a5c8-4316-93c0-8656b35775ee)
However, when we remove the filter from an existing subs, the default filter is not created and the subs become unreachable (no filter, no messages consumed). This fix create a default filter which captures all messages and we don't have to rely on Azure.
